### PR TITLE
Add IEntityTypeConfiguration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# Authentication-Authorization
+# Authentication & Authorization
+
+This repository contains a basic .NET 8 solution demonstrating a layered architecture for issuing JWT tokens. The solution is composed of several class libraries and a Web API project:
+
+- **WebApi** – ASP.NET Core Web API exposing authentication endpoints and custom middleware.
+- **ServiceCore.Interfaces** – Interfaces for services and repositories.
+- **ServiceCore** – Business logic implementation including JWT token generation.
+- **Infrastructure** – Generic repository and unit of work implementation.
+ - **Models.Data** – Entity Framework Core models and `DbContext` with Fluent API configuration.
+- **Models.Client** – DTOs used by the API.
+
+The API uses an in-memory database for demonstration and registers all dependencies through DI. A simple JWT middleware is included and can be expanded for custom validation.
+
+## Building
+
+```
+# restore dependencies (requires .NET 8 SDK)
+dotnet restore
+
+# build the solution
+dotnet build
+```
+
+## Running the API
+
+```
+dotnet run --project src/WebApi/WebApi.csproj
+```
+
+POST `/api/auth/login` with a JSON body to receive a JWT token.

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Models.Data/Models.Data.csproj" />
+    <ProjectReference Include="../ServiceCore.Interfaces/ServiceCore.Interfaces.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Infrastructure/Repositories/GenericRepository.cs
+++ b/src/Infrastructure/Repositories/GenericRepository.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+using ServiceCore.Interfaces.Repositories;
+
+namespace Infrastructure.Repositories
+{
+    public class GenericRepository<T, C> : IGenericRepository<T>
+        where T : class
+        where C : DbContext
+    {
+        protected readonly C _context;
+        protected readonly DbSet<T> _dbSet;
+
+        public GenericRepository(C context)
+        {
+            _context = context;
+            _dbSet = context.Set<T>();
+        }
+
+        public async Task<IEnumerable<T>> Get(Expression<Func<T, bool>> filter = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            bool ignoreQueryFilters = false)
+        {
+            IQueryable<T> query = _dbSet;
+            if (filter != null)
+                query = query.Where(filter);
+            if (orderBy != null)
+                query = orderBy(query);
+            return await query.ToListAsync();
+        }
+
+        public async Task<PagingList<T>> Search(Expression<Func<T, bool>> filter = null,
+            int? pageSize = null,
+            int pageNumber = 1,
+            SortDirection sortDirection = SortDirection.Ascending,
+            string sortField = "",
+            bool IsInclude = false,
+            bool ignoreQueryFilters = false)
+        {
+            IQueryable<T> query = _dbSet;
+            if (filter != null)
+                query = query.Where(filter);
+            var items = await query.Skip((pageNumber - 1) * (pageSize ?? 10)).Take(pageSize ?? 10).ToListAsync();
+            return new PagingList<T> { Items = items, TotalCount = await query.CountAsync() };
+        }
+
+        public async Task<T> GetById(object id) => await _dbSet.FindAsync(id);
+
+        public async Task<T> Insert(T entity)
+        {
+            _dbSet.Add(entity);
+            await _context.SaveChangesAsync();
+            return entity;
+        }
+
+        public async Task<T> Update(T entityToUpdate)
+        {
+            _context.Entry(entityToUpdate).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return entityToUpdate;
+        }
+
+        public IQueryable<T> GetQuery(Expression<Func<T, bool>> filter = null, bool IsInclude = false, bool ignoreQueryFilters = false)
+        {
+            IQueryable<T> query = _dbSet;
+            if (filter != null)
+                query = query.Where(filter);
+            return query;
+        }
+
+        public async Task<List<T>> UpdateRange(List<T> entitiesToUpdate)
+        {
+            _dbSet.UpdateRange(entitiesToUpdate);
+            await _context.SaveChangesAsync();
+            return entitiesToUpdate;
+        }
+
+        public async Task<List<T>> AddRange(List<T> entitiesToUpdate)
+        {
+            await _dbSet.AddRangeAsync(entitiesToUpdate);
+            await _context.SaveChangesAsync();
+            return entitiesToUpdate;
+        }
+
+        public Task<PagingList<T>> ExecuteStoredProcedure<I>(string procedureName, I input, string parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<List<dynamic>>> ExecuteStoredProcedureDataSet<I>(string procedureName, I input)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Infrastructure/Repositories/UnitOfWork.cs
+++ b/src/Infrastructure/Repositories/UnitOfWork.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using ServiceCore.Interfaces.Repositories;
+
+namespace Infrastructure.Repositories
+{
+    public class UnitOfWork<C> : IUnitOfWork<C> where C : DbContext
+    {
+        private readonly C _context;
+        private readonly Dictionary<Type, object> _repositories = new();
+
+        public UnitOfWork(C context)
+        {
+            _context = context;
+        }
+
+        public IGenericRepository<T> GetRepository<T>() where T : class
+        {
+            if (_repositories.ContainsKey(typeof(T)))
+                return (IGenericRepository<T>)_repositories[typeof(T)];
+
+            var repo = new GenericRepository<T, C>(_context);
+            _repositories.Add(typeof(T), repo);
+            return repo;
+        }
+
+        public void SaveChanges()
+        {
+            _context.SaveChanges();
+        }
+
+        public Task<int?> ExecuteStoredProcedure<I>(string query, I input, string output = "", bool forJob = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<dynamic> ExecuteStoredProcedure<I, O>(string procedureName, I input, string output = null) where O : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool?> ExecuteStoredProcedureWithBooleanResult<I>(string procedureName, I input)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Models.Client/DTOs/LoginRequest.cs
+++ b/src/Models.Client/DTOs/LoginRequest.cs
@@ -1,0 +1,8 @@
+namespace Models.Client.DTOs
+{
+    public class LoginRequest
+    {
+        public string UserName { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/src/Models.Client/DTOs/LoginResponse.cs
+++ b/src/Models.Client/DTOs/LoginResponse.cs
@@ -1,0 +1,7 @@
+namespace Models.Client.DTOs
+{
+    public class LoginResponse
+    {
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/src/Models.Client/Models.Client.csproj
+++ b/src/Models.Client/Models.Client.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/Models.Data/AppDbContext.cs
+++ b/src/Models.Data/AppDbContext.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Models.Data.Entities;
+using Models.Data.Configurations;
+
+namespace Models.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<User> Users => Set<User>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.ApplyConfiguration(new UserConfiguration());
+        }
+    }
+}

--- a/src/Models.Data/Configurations/UserConfiguration.cs
+++ b/src/Models.Data/Configurations/UserConfiguration.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Models.Data.Entities;
+
+namespace Models.Data.Configurations
+{
+    public class UserConfiguration : IEntityTypeConfiguration<User>
+    {
+        public void Configure(EntityTypeBuilder<User> builder)
+        {
+            builder.HasKey(u => u.Id);
+            builder.Property(u => u.UserName).IsRequired();
+        }
+    }
+}

--- a/src/Models.Data/Entities/User.cs
+++ b/src/Models.Data/Entities/User.cs
@@ -1,0 +1,9 @@
+namespace Models.Data.Entities
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string UserName { get; set; } = string.Empty;
+        public string PasswordHash { get; set; } = string.Empty;
+    }
+}

--- a/src/Models.Data/Models.Data.csproj
+++ b/src/Models.Data/Models.Data.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/ServiceCore.Interfaces/Repositories/IGenericRepository.cs
+++ b/src/ServiceCore.Interfaces/Repositories/IGenericRepository.cs
@@ -1,0 +1,43 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace ServiceCore.Interfaces.Repositories
+{
+    public interface IGenericRepository<T> where T : class
+    {
+        Task<IEnumerable<T>> Get(
+            Expression<Func<T, bool>> filter = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            bool ignoreQueryFilters = false);
+
+        Task<PagingList<T>> Search(
+            Expression<Func<T, bool>> filter = null,
+            int? pageSize = null,
+            int pageNumber = 1,
+            SortDirection sortDirection = SortDirection.Ascending,
+            string sortField = "",
+            bool IsInclude = false,
+            bool ignoreQueryFilters = false);
+
+        Task<T> GetById(object id);
+        Task<T> Insert(T entity);
+        Task<T> Update(T entityToUpdate);
+        IQueryable<T> GetQuery(Expression<Func<T, bool>> filter = null, bool IsInclude = false, bool ignoreQueryFilters = false);
+        Task<List<T>> UpdateRange(List<T> entitiesToUpdate);
+        Task<List<T>> AddRange(List<T> entitiesToUpdate);
+        Task<PagingList<T>> ExecuteStoredProcedure<I>(string procedureName, I input, string parameters);
+        Task<List<List<dynamic>>> ExecuteStoredProcedureDataSet<I>(string procedureName, I input);
+    }
+
+    public enum SortDirection
+    {
+        Ascending,
+        Descending
+    }
+
+    public class PagingList<T>
+    {
+        public IEnumerable<T> Items { get; set; } = new List<T>();
+        public int TotalCount { get; set; }
+    }
+}

--- a/src/ServiceCore.Interfaces/Repositories/IUnitOfWork.cs
+++ b/src/ServiceCore.Interfaces/Repositories/IUnitOfWork.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ServiceCore.Interfaces.Repositories
+{
+    public interface IUnitOfWork<C> where C : DbContext
+    {
+        void SaveChanges();
+        IGenericRepository<T> GetRepository<T>() where T : class;
+        Task<int?> ExecuteStoredProcedure<I>(string query, I input, string output = "", bool forJob = false);
+        Task<dynamic> ExecuteStoredProcedure<I, O>(string procedureName, I input, string output = null) where O : class;
+        Task<bool?> ExecuteStoredProcedureWithBooleanResult<I>(string procedureName, I input);
+    }
+}

--- a/src/ServiceCore.Interfaces/ServiceCore.Interfaces.csproj
+++ b/src/ServiceCore.Interfaces/ServiceCore.Interfaces.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Models.Data/Models.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ServiceCore.Interfaces/Services/IJwtService.cs
+++ b/src/ServiceCore.Interfaces/Services/IJwtService.cs
@@ -1,0 +1,7 @@
+namespace ServiceCore.Interfaces.Services
+{
+    public interface IJwtService
+    {
+        string GenerateToken(string userId, string userName);
+    }
+}

--- a/src/ServiceCore/ServiceCore.csproj
+++ b/src/ServiceCore/ServiceCore.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ServiceCore.Interfaces/ServiceCore.Interfaces.csproj" />
+    <ProjectReference Include="../Infrastructure/Infrastructure.csproj" />
+    <ProjectReference Include="../Models.Data/Models.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ServiceCore/Services/AuthService.cs
+++ b/src/ServiceCore/Services/AuthService.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Models.Client.DTOs;
+using Models.Data;
+using Models.Data.Entities;
+using ServiceCore.Interfaces.Repositories;
+using ServiceCore.Interfaces.Services;
+
+namespace ServiceCore.Services
+{
+    public class AuthService
+    {
+        private readonly IUnitOfWork<AppDbContext> _uow;
+        private readonly IJwtService _jwtService;
+
+        public AuthService(IUnitOfWork<AppDbContext> uow, IJwtService jwtService)
+        {
+            _uow = uow;
+            _jwtService = jwtService;
+        }
+
+        public async Task<LoginResponse> Login(LoginRequest request)
+        {
+            var repo = _uow.GetRepository<User>();
+            var users = await repo.Get(u => u.UserName == request.UserName);
+            var user = users.FirstOrDefault();
+            if (user == null) return null;
+
+            // password check omitted
+            var token = _jwtService.GenerateToken(user.Id.ToString(), user.UserName);
+            return new LoginResponse { Token = token };
+        }
+    }
+}

--- a/src/ServiceCore/Services/JwtService.cs
+++ b/src/ServiceCore/Services/JwtService.cs
@@ -1,0 +1,39 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using ServiceCore.Interfaces.Services;
+
+namespace ServiceCore.Services
+{
+    public class JwtService : IJwtService
+    {
+        private readonly string _secret;
+        private readonly string _issuer;
+
+        public JwtService(string secret, string issuer)
+        {
+            _secret = secret;
+            _issuer = issuer;
+        }
+
+        public string GenerateToken(string userId, string userName)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.ASCII.GetBytes(_secret);
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, userId),
+                    new Claim(ClaimTypes.Name, userName)
+                }),
+                Expires = DateTime.UtcNow.AddHours(1),
+                Issuer = _issuer,
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+            };
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}

--- a/src/WebApi/Controllers/AuthController.cs
+++ b/src/WebApi/Controllers/AuthController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using Models.Client.DTOs;
+using ServiceCore.Services;
+
+namespace WebApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly AuthService _authService;
+
+        public AuthController(AuthService authService)
+        {
+            _authService = authService;
+        }
+
+        [HttpPost("login")]
+        public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginRequest request)
+        {
+            var result = await _authService.Login(request);
+            if (result == null) return Unauthorized();
+            return Ok(result);
+        }
+    }
+}

--- a/src/WebApi/Middleware/JwtMiddleware.cs
+++ b/src/WebApi/Middleware/JwtMiddleware.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace WebApi.Middleware
+{
+    public class JwtMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public JwtMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // Custom JWT validation logic can go here
+            await _next(context);
+        }
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Models.Data;
+using ServiceCore.Interfaces.Repositories;
+using ServiceCore.Interfaces.Services;
+using ServiceCore.Services;
+using Infrastructure.Repositories;
+using WebApi.Middleware;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseInMemoryDatabase("AuthDb"));
+
+builder.Services.AddScoped<IUnitOfWork<AppDbContext>, UnitOfWork<AppDbContext>>();
+builder.Services.AddScoped<IJwtService>(_ => new JwtService("supersecretkey", "DemoIssuer"));
+builder.Services.AddScoped<AuthService>();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.UseMiddleware<JwtMiddleware>();
+app.MapControllers();
+app.Run();

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ServiceCore/ServiceCore.csproj" />
+    <ProjectReference Include="../ServiceCore.Interfaces/ServiceCore.Interfaces.csproj" />
+    <ProjectReference Include="../Infrastructure/Infrastructure.csproj" />
+    <ProjectReference Include="../Models.Data/Models.Data.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `UserConfiguration` implementing `IEntityTypeConfiguration` for fluent API
- register entity configuration in `AppDbContext`
- mention fluent configuration in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685878c029808329bf489518e8c224cd